### PR TITLE
Add x86_64-unknown-uefi toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-targets = ["x86_64-unknown-uefi"]
+targets = ["x86_64-unknown-uefi", "i686-unknown-uefi"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Makefile and Rust toolchain configurations to support additional target architectures and improved build path logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->